### PR TITLE
Add fuzzing by way of ClusterFuzzLite

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,0 +1,6 @@
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update && apt-get install -y make autoconf automake libtool
+
+COPY . $SRC/tipa
+COPY .clusterfuzzlite/build.sh $SRC/build.sh
+WORKDIR $SRC/tipa

--- a/.clusterfuzzlite/README.md
+++ b/.clusterfuzzlite/README.md
@@ -1,0 +1,3 @@
+# ClusterFuzzLite set up
+
+This folder holds logic for fuzzing by way of [ClusterfuzzLite](https://google.github.io/clusterfuzzlite).

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,0 +1,11 @@
+mkdir build
+cd build
+cmake ../
+make
+
+# Copy all fuzzer executables to $OUT/
+$CXX $CFLAGS $LIB_FUZZING_ENGINE \
+  $SRC/tipa/.clusterfuzzlite/fuzz_parse.cpp \
+  -o $OUT/fuzz_parse \
+  -I$SRC/tipa/src/ \
+  $SRC/tipa/build/src/libtipa.a

--- a/.clusterfuzzlite/fuzz_parse.cpp
+++ b/.clusterfuzzlite/fuzz_parse.cpp
@@ -1,0 +1,28 @@
+#include <fuzzer/FuzzedDataProvider.h>
+
+#include <sstream>
+#include <string>
+#include <tinyparser.hpp>
+
+using namespace std;
+using namespace tipa;
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  FuzzedDataProvider fdp(data, size);
+
+  std::string fuzz_s1 = fdp.ConsumeRandomLengthString();
+  std::string fuzz_s2 = fdp.ConsumeRandomLengthString();
+  std::string fuzz_s3 = fdp.ConsumeRandomLengthString();
+
+  rule expr = rule(tk_int) >> rule('+') >> rule(tk_int) >> rule(tk_ident) >>
+              rule("(") >> rule(tk_int) >> rule(")") >> rule(";") >>
+              rule(fuzz_s2) >> rule(fuzz_s3);
+
+  stringstream str(fuzz_s1);
+  parser_context pc;
+  pc.set_stream(str);
+
+  parse_all(expr, pc);
+
+  return 0;
+}

--- a/.clusterfuzzlite/project.yaml
+++ b/.clusterfuzzlite/project.yaml
@@ -1,0 +1,1 @@
+language: c++

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -1,0 +1,34 @@
+name: ClusterFuzzLite PR fuzzing
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [ master ]
+    paths: [ src/** ]
+
+permissions: read-all
+jobs:
+  PR:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        sanitizer: [address]
+    steps:
+    - name: Build Fuzzers (${{ matrix.sanitizer }})
+      id: build
+      uses: google/clusterfuzzlite/actions/build_fuzzers@v1
+      with:
+        sanitizer: ${{ matrix.sanitizer }}
+        language: c++
+        bad-build-check: false
+        ##storage-repo: https://${{ secrets.PERSONAL_ACCESS_TOKEN }}@github.com/ossf/fuzz-introspector.git
+        #storage-repo-branch-coverage: gh-pages  # Optional. Defaults to "gh-pages".
+    - name: Run Fuzzers (${{ matrix.sanitizer }})
+      id: run
+      uses: google/clusterfuzzlite/actions/run_fuzzers@v1
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        fuzz-seconds: 100
+        mode: 'code-change'
+        report-unreproducible-crashes: false
+        sanitizer: ${{ matrix.sanitizer }}


### PR DESCRIPTION
This adds fuzzing by way of [ClusterFuzzLite](https://google.github.io/clusterfuzzlite/), which is a GitHub action that will perform a short amount of fuzzing for new PRs. The goal is to use fuzzing to catch bugs that may be introduced by new PRs.

I added a fuzzer that sets up a simple expression with a bit of fuzzer-seeded data in the parser generation, and then tries it parse fuzzer input. Currently the timeout is set to 100 seconds, meaning the fuzzer will run 100 seconds each PR. CFLite will flag if the fuzzer finds  any issues in the code introduced by a PR.